### PR TITLE
Modify default smiles-drawer options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -57,10 +57,14 @@ export default class ChemPlugin extends Plugin {
 			source: string,
 			container: HTMLElement,
 			theme: string,
-			width: string
+			width: string,
+			options?: object
 		) => {
 			// can put options in calling the drawer
-			const drawer = new SmilesDrawer.SmiDrawer(DEFAULT_SD_OPTIONS);
+			const drawer = new SmilesDrawer.SmiDrawer({
+				...DEFAULT_SD_OPTIONS,
+				...options,
+			});
 
 			// different behavior in live preview and view mode
 			// under view mode, an extra '\n' is appended
@@ -68,7 +72,7 @@ export default class ChemPlugin extends Plugin {
 
 			for (let i = 0; i < rows.length; i++) {
 				const img = container.createEl('img') as HTMLImageElement;
-				img.width = parseInt(width);
+				//img.width = parseInt(width);
 				drawer.draw(
 					rows[i].trim(), // handle spaces in front of the string
 					img,
@@ -85,7 +89,8 @@ export default class ChemPlugin extends Plugin {
 					!document.body.hasClass('theme-light')
 					? this.settings.darkTheme
 					: this.settings.lightTheme,
-				this.settings.width
+				this.settings.width,
+				this.settings.options
 			);
 		});
 

--- a/src/settings/SettingTab.ts
+++ b/src/settings/SettingTab.ts
@@ -99,24 +99,43 @@ export class ChemSettingTab extends PluginSettingTab {
 		const lightCard = div.createEl('div', { cls: 'chemcard theme-light' });
 		const darkCard = div.createEl('div', { cls: 'chemcard theme-dark' });
 
-		// TODO: fill advance
-		// dealing with performance problem
-		containerEl.createEl('h2', { text: 'Advanced Settings' });
+		new Setting(containerEl)
+			.setName('Advanced Settings')
+			.setDesc('Configure smiles drawer options.')
+			.setHeading();
 
 		new Setting(containerEl)
 			.setName('Scale')
-			.setDesc('Adjust the scale of the molecule image.')
-			.addText((text) =>
-				text
-					.setValue(
-						this.plugin.settings.options.scale?.toString() ?? '1'
-					)
-					.setPlaceholder('1')
+			.setDesc('Adjust the global molecule scale.')
+			.addButton((button) =>
+				button.setIcon('rotate-ccw').onClick(async () => {
+					this.plugin.settings.options.scale = 1;
+					await this.plugin.saveSettings();
+					onOptionChange();
+				})
+			)
+			.addSlider((slider) =>
+				slider
+					.setValue(this.plugin.settings.options.scale ?? 1)
+					.setLimits(0, 5, 1)
+					.setDynamicTooltip()
 					.onChange(async (value) => {
-						if (value == '') {
-							value = '1';
-						}
-						this.plugin.settings.options.scale = parseInt(value);
+						this.plugin.settings.options.scale = value;
+						await this.plugin.saveSettings();
+						onOptionChange();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName('Compact Drawing')
+			.setDesc('Enable to linearize simple structures. (Unrecommanded)')
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.options.compactDrawing ?? false
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.options.compactDrawing = value;
 						await this.plugin.saveSettings();
 						onOptionChange();
 					})

--- a/src/settings/base.ts
+++ b/src/settings/base.ts
@@ -7,6 +7,7 @@ export interface ChemPluginSettings {
 	darkTheme: string;
 	lightTheme: string;
 	sample: string;
+	options: Partial<SMILES_DRAWER_OPTIONS>; //TODO: reduce interface exposure.
 }
 
 export const DEFAULT_SETTINGS: ChemPluginSettings = {
@@ -14,6 +15,7 @@ export const DEFAULT_SETTINGS: ChemPluginSettings = {
 	darkTheme: 'dark',
 	lightTheme: 'light',
 	sample: SAMPLE_SMILES,
+	options: {},
 };
 
 // Smiles-drawer options
@@ -44,7 +46,7 @@ export interface SMILES_DRAWER_OPTIONS {
 }
 
 export const DEFAULT_SD_OPTIONS: SMILES_DRAWER_OPTIONS = {
-	scale: 0,
+	scale: 1,
 	bondThickness: 1,
 	shortBondLength: 0.8,
 	bondSpacing: 5.1,
@@ -55,7 +57,7 @@ export const DEFAULT_SD_OPTIONS: SMILES_DRAWER_OPTIONS = {
 	explicitHydrogens: true,
 	overlapSensitivity: 0.42,
 	overlapResolutionIterations: 1,
-	compactDrawing: true,
+	compactDrawing: false,
 	fontFamily: 'Arial, Helvetica, sans-serif',
 	fontSizeLarge: 11,
 	fontSizeSmall: 3,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	"strictNullChecks": true,
+    "strictNullChecks": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
- Change the default value of `scale` to 1, aiming to solve #14 
- Disable `compactDrawing` option by default
- Provide config UI prototype in the plugin setting tab