### PR TITLE
Add options for explicit hydrogen

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -55,6 +55,10 @@
                 "terminal-carbons": {
                     "name": "Show terminal carbons",
                     "description": "Explictly draw terminal carbons like methyl or methylene."
+                },
+                "explicit-hydrogen": {
+                    "name": "Explicit hydrogen",
+                    "description": "Enable to show explicit hydrogen."
                 }
             },
             "copy": {

--- a/src/lib/translations/zh-CN.json
+++ b/src/lib/translations/zh-CN.json
@@ -55,6 +55,10 @@
                 "terminal-carbons": {
                     "name": "端基碳",
                     "description": "显式绘出末端甲基、亚甲基等端基碳。"
+                },
+                "explicit-hydrogen": {
+                    "name": "显式氢",
+                    "description": "启用以绘制显式氢原子。"
                 }
             },
             "copy": {

--- a/src/settings/SettingTab.ts
+++ b/src/settings/SettingTab.ts
@@ -182,6 +182,25 @@ export class ChemSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName(i18n.t('settings.advanced.explicit-hydrogen.name'))
+			.setDesc(i18n.t('settings.advanced.explicit-hydrogen.description'))
+			.addToggle((toggle) =>
+				toggle
+					.setValue(
+						this.plugin.settings.options?.explicitHydrogens ?? false
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.options.explicitHydrogens = value;
+						await this.plugin.saveSettings();
+						setDrawer({
+							...DEFAULT_SD_OPTIONS,
+							...this.plugin.settings.options,
+						});
+						onSettingsChange();
+					})
+			);
+
+		new Setting(containerEl)
 			.setName(i18n.t('settings.copy.title'))
 			.setHeading();
 


### PR DESCRIPTION
Closes #56 

### Test cases
Check these cases with the config enabled/disabled to see the difference:
- Chiral center related: `N[C@@H](C)C(=O)O` & `N[C@H](C)C(=O)O`
- Explicit: `[H][O]C(=O)C(C)=CC1=CC=CC=C1`
- Implicit: `OC(=O)C(C)=CC1=CC=CC=C1`

### Explaination

The term `explicit hydrogen` is a little bit confusing. Here's a brief intro quoted from https://www.herongyang.com/Cheminformatics/SMILES-Hydrogen-Representations.html

> **How Hydrogens Are Represented in SMILES?** - Hydrogen are represented according to the following rules:
> 1. Explicitly as Atoms - A hydrogen can be represented by its atomic symbol in square brackets [H]. For example, [H][O][H] for water; [2H]O[2H] for heavy water; [H][H] for hydrogen molecule.
> 2. Explicitly as Counts - When hydrogens are connected to an atom, which is represented in square brackets, those hydrogens must be represented a count in the form of [xHn]. For example, "[OH2]" is the same as "O([H])[H]"
> 3. Implicitly - When hydrogens are connected to an atom, which is represented without square brackets, those hydrogens are implicitly represented according to normal valence assumptions. For example, "O" is the same as "O([H])[H]"