### PR TITLE
Add ability to display names under compounds with RDKit

### DIFF
--- a/src/lib/core/rdkitCore.ts
+++ b/src/lib/core/rdkitCore.ts
@@ -111,6 +111,7 @@ export default class RDKitCore implements ChemCore {
 			JSON.stringify({
 				...DEFAULT_RDKIT_OPTIONS,
 				...this.settings.rdkitOptions,
+				legend: mol.has_prop('_Name') ? mol.get_prop('_Name') : '',
 				atomColourPalette: palette,
 				queryColour: palette['6'],
 				highlightColour: palette['6'],


### PR DESCRIPTION
Use RDKit.js's ability to detect a compound's `_Name` property and display it in the `legend`. Closes #75.

I looked through smilesDrawer's source code and unfortunately could not find any equivalent. As far as I can tell, it's only possible with RDKit.

**Syntax**:

```smiles
C1([Cl])=CC=CC(C(=O)O[OH])=C1 mCPBA
```

**Result**:

![2024-12-14_18-32-46](https://github.com/user-attachments/assets/ea780a5d-1e0e-4cfb-8607-e9073fd176dc)