### PR TITLE
Add bond thickness setting

### DIFF
--- a/src/lib/core/rdkitOptions.ts
+++ b/src/lib/core/rdkitOptions.ts
@@ -17,6 +17,7 @@ export interface RDKitOptions {
 	explicitMethyl: boolean;
 	fixedBondLength: number;
 	fixedScale: number;
+	bondLineWidth: number;
 	atomColourPalette: Record<number, RGBDecimal>; // any atom index is a valid palette key
 	includeRadicals: boolean;
 	clearBackground: boolean;
@@ -30,6 +31,7 @@ export const DEFAULT_RDKIT_OPTIONS: RDKitOptions = {
 	explicitMethyl: false,
 	fixedBondLength: -1,
 	fixedScale: -1,
+	bondLineWidth: 1,
 	atomColourPalette: convertToRDKitTheme('rdkit-default'),
 	includeRadicals: true,
 	clearBackground: false,

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -66,6 +66,10 @@
 				"explicit-hydrogen": {
 					"name": "Explicit hydrogen",
 					"description": "Enable to show explicit hydrogen."
+				},
+				"bond-thickness": {
+					"name": "Bond thickness",
+					"description": "Set the bond line width."
 				}
 			},
 			"copy": {

--- a/src/lib/translations/zh-CN.json
+++ b/src/lib/translations/zh-CN.json
@@ -66,6 +66,10 @@
 				"explicit-hydrogen": {
 					"name": "显式氢",
 					"description": "启用以绘制显式氢原子。"
+				},
+				"bond-thickness": {
+					"name": "键宽",
+					"description": "Set the bond line width."
 				}
 			},
 			"copy": {

--- a/src/settings/SettingTab.ts
+++ b/src/settings/SettingTab.ts
@@ -212,6 +212,27 @@ export class ChemSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName(i18n.t('settings.advanced.bond-thickness.name'))
+			.setDesc(i18n.t('settings.advanced.bond-thickness.description'))
+			.addText((text) =>
+				text
+					.setValue(
+						(
+							this.plugin.settings.smilesDrawerOptions.moleculeOptions
+								.bondThickness ?? 1
+						).toString()
+					)
+					.onChange(async (value) => {
+						const fVal = parseFloat(value);
+						this.plugin.settings.smilesDrawerOptions.moleculeOptions.bondThickness =
+							fVal;
+						this.plugin.settings.rdkitOptions.bondLineWidth = fVal;
+						await this.plugin.saveSettings();
+						onSettingsChange();
+					})
+			);
+
+		new Setting(containerEl)
 			.setName(i18n.t('settings.copy.title'))
 			.setHeading();
 


### PR DESCRIPTION
Sets the bond thickness for RDKIt to be the same as for Smiles Drawer, and adds a bond thickness option in the Setting Tab.

Currently, Smiles Drawer has a `bondThickness` of `1` by default, but RDKit does not have `bondLineWidth` set. So, RDKit looks much thicker than Smiles Drawer. I believe setting RDKit's `bondLineWidth` to also be `1` is more consistent and readable. The user can then customize this for both render cores.

This pull request is mostly done, but there are some things I haven't finalized.

Where in the settings should bond thickness be? I put it in the Advanced section for now, but it could also be next to themes. Or could there be a new Appearance section for minor settings like bond thickness, short bond length, font size, legend font size, etc.?

Also, I haven't sorted out the Chinese localization.